### PR TITLE
feat: association in API Proxy, for IP rotation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Merci de contribuer à RNCS-API-PROXY ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)
+Merci de contribuer à Annuaire-entreprises-api-proxy ! Effacez cette ligne ainsi que, pour chaque ligne ci-dessous, les cas ne correspondant pas à votre contribution :)
 
 - Amélioration technique. | Correction d'un bug. | Changement mineur.
 - Zones impactées : `chemin/vers/le/fichier/contenant/les/variables/impactées`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Proxy API
 
-[![Pre-merge checks](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/pre-merge.yml/badge.svg)](https://github.com/etalab/rncs-api-proxy/actions/workflows/pre-merge.yml)
-[![Deploy - Staging](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-staging.yml/badge.svg)](https://github.com/etalab/rncs-api-proxy/actions/workflows/deploy-staging.yml)
-[![Deploy - Production](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-production.yml/badge.svg)](https://github.com/etalab/rncs-api-proxy/actions/workflows/deploy-production.yml)
+[![Pre-merge checks](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/pre-merge.yml/badge.svg)](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/pre-merge.yml)
+[![Deploy - Staging](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-staging.yml/badge.svg)](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-staging.yml)
+[![Deploy - Production](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-production.yml/badge.svg)](https://github.com/etalab/annuaire-entreprises-proxy/actions/workflows/deploy-production.yml)
 
 Ce proxy permet de proxifier certains appels a des API utilisées par l'Annuaire des Entreprises.
 
@@ -16,7 +16,7 @@ Ce repository fait partie d'un ensemble de services qui constituent l'[Annuaire 
 | L’API du Moteur de recherche   | [par ici 👉](https://github.com/etalab/annuaire-entreprises-search-api)   |
 | L‘API de redondance de Sirene  | [par ici 👉](https://github.com/etalab/annuaire-entreprises-sirene-api)   |
 | L‘infra du moteur de recherche | [par ici 👉](https://github.com/etalab/annuaire-entreprises-search-infra) |
-| Le proxy API du site           | [par ici 👉](https://github.com/etalab/annuaire-entreprises-api-proxy)                    |
+| Le proxy API du site           | [par ici 👉](https://github.com/etalab/annuaire-entreprises-api-proxy)    |
 
 ## Installation
 
@@ -49,7 +49,7 @@ https://rncs-proxy.api.gouv.fr/document/justificatif/job/status
 // download an existing file with the slug given on job creation
 https://rncs-proxy.api.gouv.fr/document/downloads/:slug
 
-// status 
+// status
 https://rncs-proxy.api.gouv.fr/status/imr/api
 https://rncs-proxy.api.gouv.fr/status/imr/site
 ```
@@ -70,9 +70,9 @@ npm run test
 
 ### Deploiement
 
-Le déploiement se fait par [Github action](https://github.com/etalab/rncs-api-proxy/actions)
+Le déploiement se fait par [Github action](https://github.com/etalab/annuaire-entreprises-proxy/actions)
 
-A chaque "merge" sur master : 
+A chaque "merge" sur master :
 
 - Laissez le déploiement se faire automatiquement sur staging via l'action [deploy-staging](https://github.com/etalab/annuaire-entreprises-api-proxy/actions/workflows/deploy-staging.yml)
 - Vérifiez vos changements sur staging

--- a/index.ts
+++ b/index.ts
@@ -4,9 +4,9 @@ import { imrController } from './src/controllers/imr';
 import { errorHandler } from './src/controllers/errorHandler';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
-import documentRouter from './src/routes/document';
 import helmet from 'helmet';
 import statusRouter from './src/routes/status';
+import { clientAssociation } from './src/clients/association';
 
 dotenv.config();
 
@@ -71,6 +71,11 @@ app.get('/imr/:siren', imrController);
  * Status
  */
 app.use('/status', statusRouter);
+
+/**
+ * Association
+ */
+app.use('/association/:rna', clientAssociation);
 
 /**
  * Error handling

--- a/index.ts
+++ b/index.ts
@@ -2,11 +2,11 @@ import express, { Express, Request, Response } from 'express';
 import dotenv from 'dotenv';
 import { imrController } from './src/controllers/imr';
 import { errorHandler } from './src/controllers/errorHandler';
+import { associationController } from './src/controllers/association';
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
 import helmet from 'helmet';
 import statusRouter from './src/routes/status';
-import { clientAssociation } from './src/clients/association';
 
 dotenv.config();
 
@@ -75,7 +75,7 @@ app.use('/status', statusRouter);
 /**
  * Association
  */
-app.use('/association/:rna', clientAssociation);
+app.use('/association/:rna', associationController);
 
 /**
  * Error handling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rncs-api-proxy",
+  "name": "annuaire-entreprises-api-proxy",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rncs-api-proxy",
+      "name": "annuaire-entreprises-api-proxy",
       "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "rncs-api-proxy",
+  "name": "annuaire-entreprises-api-proxy",
   "version": "1.0.0",
   "description": "",
   "main": "index.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/etalab/rncs-api-proxy.git"
+    "url": "git+https://github.com/etalab/annuaire-entreprises-api-proxy.git"
   },
   "engines": {
     "node": ">=16.4",
@@ -14,9 +14,9 @@
   "author": "Etalab",
   "license": "AGPL-3.0-or-later",
   "bugs": {
-    "url": "https://github.com/etalab/rncs-api-proxy/issues"
+    "url": "https://github.com/etalab/annuaire-entreprises-api-proxy/issues"
   },
-  "homepage": "https://github.com/etalab/rncs-api-proxy#readme",
+  "homepage": "https://github.com/etalab/annuaire-entreprises-api-proxy#readme",
   "scripts": {
     "dev": "nodemon index.ts",
     "start": "node dist/index.js",

--- a/src/clients/association/index.ts
+++ b/src/clients/association/index.ts
@@ -4,7 +4,6 @@ import constants from '../../constants';
 
 export const clientAssociation = async (rna: string): Promise<string> => {
   const url = `${routes.association}${rna}`;
-
   const response = await httpGet(url, { timeout: constants.defaultTimeout });
   const { data } = response;
   return data;

--- a/src/clients/association/index.ts
+++ b/src/clients/association/index.ts
@@ -1,0 +1,11 @@
+import routes from '../urls';
+import { httpGet } from '../../utils/network';
+import constants from '../../constants';
+
+export const clientAssociation = async (rna: string): Promise<string> => {
+  const url = `${routes.association}${rna}`;
+
+  const response = await httpGet(url, { timeout: constants.defaultTimeout });
+  const { data } = response;
+  return data;
+};

--- a/src/clients/urls.ts
+++ b/src/clients/urls.ts
@@ -14,6 +14,7 @@ const routes = {
       },
     },
   },
+  association: 'https://siva-integ1.cegedim.cloud/apim/api-asso/api/structure/',
 };
 
 export default routes;

--- a/src/controllers/association.ts
+++ b/src/controllers/association.ts
@@ -1,0 +1,16 @@
+import { Request, Response, NextFunction } from 'express';
+import { clientAssociation } from '../clients/association';
+
+export const associationController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const rna = req.params?.rna;
+    const association = await clientAssociation(rna);
+    res.status(200).json(association);
+  } catch (e) {
+    next(e);
+  }
+};


### PR DESCRIPTION
Add a proxy route : 
`association/:rna`

In order to be called from site while using IP rotation

Also rename a bunch of file as this is no longer rncs-centric