### PR TITLE
feat: increase inpi timeout to match #640

### DIFF
--- a/src/clients/inpi/api-rne/index.ts
+++ b/src/clients/inpi/api-rne/index.ts
@@ -20,7 +20,7 @@ import { IRNEResponse } from './interface';
 export const fetchImmatriculationFromAPIRNE = async (siren: Siren) => {
   const response = await authApiRneClient(
     routes.inpi.api.rne.cmc.companies + siren,
-    { timeout: constants.timeout.M }
+    { timeout: constants.timeout.XL }
   );
   const data = response.data as IRNEResponse;
 

--- a/src/clients/inpi/site/index.ts
+++ b/src/clients/inpi/site/index.ts
@@ -9,7 +9,7 @@ export const fetchImmatriculationFromSite = async (
   siren: Siren
 ): Promise<IImmatriculation> => {
   const response = await httpGet(routes.inpi.portail.entreprise + siren, {
-    timeout: constants.timeout.L,
+    timeout: constants.timeout.XXL,
   });
 
   return {


### PR DESCRIPTION
Increase both INPI timeout : 
- default call to API -> 10sec
- fallback call scrapping the website => 20 sec 

see https://github.com/etalab/annuaire-entreprises-site/pull/640